### PR TITLE
Support execution from macOS (POSIX-compatible sed)

### DIFF
--- a/autoinstall_mc12le0_OpenBMC_via_ssh.sh
+++ b/autoinstall_mc12le0_OpenBMC_via_ssh.sh
@@ -90,7 +90,7 @@ then
 fi
 
 tmpscript="$(mktemp tmp-"$(date +%F)"-OpenBMC-flash.XXXXXXX)"
-sed -n '1,/^#===ENDOFLOCALSCRIPT/{d};p' "${0}" > "${tmpscript}"
+sed -n '1,/^#===ENDOFLOCALSCRIPT/{d;};p' "${0}" > "${tmpscript}"
 
 echo "Transferring generated shellscript to MegaRAC BMC host..." >&2
 if ! ssh -oPreferredAuthentications=password -oPasswordAuthentication=yes \


### PR DESCRIPTION
Currently, the installer fails on macOS (Darwin/BSD) due to sed {d} syntax:
```
sed: 1: "1,/^#===ENDOFLOCALSCRIP ...": extra characters at the end of d command
```

This minor change still works on Linux/GNU sed, and is portable to Mac. (at minimum)

After this change, all parts work as expected on MacOS (Sequoia 15). The stock image (downgraded) is backed up as expected, and flash completes. BMC is accessible via SSH at the new DHCP IP and randomized MAC from the management port.

As far as I can tell, all the dependencies are installed by default in macOS. No strict need for Xcode CLI tools, homebrew, etc. for the install itself.

Vielen Dank Johannes; I'm excited to have oBMC on this hardware and to contribute!